### PR TITLE
Prevent duplicate note display when re-fetching location

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,6 +66,7 @@ async function deleteNote(id) {
 
 // UI and geolocation
 let currentPosition;
+let watchId;
 const locBtn = document.getElementById('locBtn');
 const notesList = document.getElementById('notesList');
 const addNoteBtn = document.getElementById('addNoteBtn');
@@ -91,15 +92,17 @@ locBtn.addEventListener('click', () => {
     currentPosition = pos;
     logPosition(pos);
   });
-  navigator.geolocation.watchPosition(pos => {
-    currentPosition = pos;
-    logPosition(pos);
-  });
+  if (watchId == null) {
+    watchId = navigator.geolocation.watchPosition(pos => {
+      currentPosition = pos;
+      logPosition(pos);
+    });
+  }
 });
 
 async function displayNotes() {
-  notesList.innerHTML = '';
   if (!currentPosition) {
+    notesList.innerHTML = '';
     const li = document.createElement('li');
     li.textContent = 'Get location to view nearby notes';
     notesList.appendChild(li);
@@ -108,6 +111,7 @@ async function displayNotes() {
 
   const { latitude, longitude } = currentPosition.coords;
   const notes = await getNotesByRadius(latitude, longitude, 100);
+  notesList.innerHTML = '';
   notes.forEach(n => {
     const li = document.createElement('li');
     const dist = Math.round(distance(latitude, longitude, n.lat, n.lon));


### PR DESCRIPTION
## Summary
- ensure only one geolocation watch is active to avoid duplicate updates
- clear the note list right before rendering nearby notes to prevent duplicates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_688f6a234534832a8fa3b990cc651ebf