### PR TITLE
Prevent duplicate notes when requesting location multiple times

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,8 +98,8 @@ locBtn.addEventListener('click', () => {
 });
 
 async function displayNotes() {
-  notesList.innerHTML = '';
   if (!currentPosition) {
+    notesList.innerHTML = '';
     const li = document.createElement('li');
     li.textContent = 'Get location to view nearby notes';
     notesList.appendChild(li);
@@ -108,6 +108,9 @@ async function displayNotes() {
 
   const { latitude, longitude } = currentPosition.coords;
   const notes = await getNotesByRadius(latitude, longitude, 100);
+  // Clear existing notes after fetching to avoid duplicates when multiple
+  // geolocation callbacks run concurrently.
+  notesList.innerHTML = '';
   notes.forEach(n => {
     const li = document.createElement('li');
     const dist = Math.round(distance(latitude, longitude, n.lat, n.lon));


### PR DESCRIPTION
## Summary
- Avoid duplicate entries when refreshing location by clearing note list after loading nearby notes.

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f6a234534832a8fa3b990cc651ebf