### PR TITLE
Stop continuous location tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ A minimal progressive web app that lets you create notes associated with your cu
 ## Development
 
 Open `index.html` in a modern browser. Click "Get location" to capture your coordinates, then add notes with the form. Notes are stored in IndexedDB and persist across reloads.
+
+Location is only retrieved when you press the button and is not tracked continuously.

--- a/app.js
+++ b/app.js
@@ -91,10 +91,6 @@ locBtn.addEventListener('click', () => {
     currentPosition = pos;
     logPosition(pos);
   });
-  navigator.geolocation.watchPosition(pos => {
-    currentPosition = pos;
-    logPosition(pos);
-  });
 });
 
 async function displayNotes() {


### PR DESCRIPTION
## Summary
- only fetch a location once when the user presses **Get location**
- document that location is retrieved on demand instead of being tracked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f76f27c90832aaabfe3d1bb340157