### PR TITLE
Move note form to top to avoid keyboard overlap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -47,7 +47,7 @@ body {
 #noteForm {
   display: none;
   position: fixed;
-  bottom: 80px;
+  top: 80px;
   right: 1rem;
   background: #fff;
   border: 1px solid #ccc;


### PR DESCRIPTION
## Summary
- Position the note form at the top of the screen instead of above the floating button to prevent mobile keyboards from covering it.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f7731ac4c832a82e50f01642d4858