### PR TITLE
Show message when no nearby notes

### DIFF
--- a/app.js
+++ b/app.js
@@ -107,6 +107,12 @@ async function displayNotes() {
   // Clear existing notes after fetching to avoid duplicates when multiple
   // geolocation callbacks run concurrently.
   notesList.innerHTML = '';
+  if (notes.length === 0) {
+    const li = document.createElement('li');
+    li.textContent = 'No nearby notes';
+    notesList.appendChild(li);
+    return;
+  }
   notes.forEach(n => {
     const li = document.createElement('li');
     const dist = Math.round(distance(latitude, longitude, n.lat, n.lon));


### PR DESCRIPTION
## Summary
- show 'No nearby notes' when current location has no stored notes

## Testing
- `npm test` *(fails: no package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_688f8cd887b8832ab55a56970c06589f