### PR TITLE
Emphasize clickable titles and show note creation date

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,8 +118,13 @@ async function displayNotes() {
     const dist = Math.round(distance(latitude, longitude, n.lat, n.lon));
 
     const title = document.createElement('span');
-    title.textContent = `${n.title} - ${dist} m`;
+    title.textContent = n.title;
     title.className = 'note-title';
+
+    const meta = document.createElement('span');
+    const date = n.createdAt ? new Date(n.createdAt).toLocaleDateString() : '';
+    meta.textContent = ` - ${dist} m${date ? ` - ${date}` : ''}`;
+    meta.className = 'note-meta';
 
     const body = document.createElement('div');
     body.textContent = n.body;
@@ -137,6 +142,7 @@ async function displayNotes() {
     });
 
     li.appendChild(title);
+    li.appendChild(meta);
     li.appendChild(del);
     li.appendChild(body);
     notesList.appendChild(li);

--- a/styles.css
+++ b/styles.css
@@ -69,9 +69,17 @@ body {
 .note-title {
   cursor: pointer;
   display: inline-block;
+  color: #6200ee;
+  text-decoration: underline;
 }
 
 .note-body {
   display: none;
   margin-top: 0.25rem;
+}
+
+.note-meta {
+  color: #555;
+  margin-left: 0.25rem;
+  font-size: 0.9em;
 }


### PR DESCRIPTION
## Summary
- style note titles with underline and accent color to indicate they can be clicked
- display each note's distance and creation date next to the title

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc20d3768832a85827d8a4a40f39c