### PR TITLE
Show loading feedback when retrieving location

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,10 +87,32 @@ locBtn.addEventListener('click', () => {
     alert('Geolocation not supported');
     return;
   }
-  navigator.geolocation.getCurrentPosition(pos => {
-    currentPosition = pos;
-    logPosition(pos);
-  });
+  const originalText = locBtn.textContent;
+  locBtn.disabled = true;
+  locBtn.textContent = 'Getting location...';
+
+  notesList.innerHTML = '';
+  const li = document.createElement('li');
+  li.textContent = 'Getting location...';
+  notesList.appendChild(li);
+
+  navigator.geolocation.getCurrentPosition(
+    pos => {
+      currentPosition = pos;
+      logPosition(pos);
+      locBtn.disabled = false;
+      locBtn.textContent = originalText;
+    },
+    () => {
+      alert('Unable to retrieve location');
+      locBtn.disabled = false;
+      locBtn.textContent = originalText;
+      notesList.innerHTML = '';
+      const li = document.createElement('li');
+      li.textContent = 'Unable to retrieve location';
+      notesList.appendChild(li);
+    }
+  );
 });
 
 async function displayNotes() {

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,11 @@ body {
   align-items: center;
 }
 
+#locBtn[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .content {
   padding: 1rem;
   margin-top: 60px;


### PR DESCRIPTION
## Summary
- Show a temporary "Getting location..." note and disable the button while awaiting geolocation results.
- Style disabled location button to appear inactive.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc4b1e310832aa91ad2d9f4a77dcb