### PR TITLE
Request persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ A minimal progressive web app that lets you create notes associated with your cu
 ## Development
 
 Open `index.html` in a modern browser. Click "Get location" to capture your coordinates, then add notes with the form. Notes are stored in IndexedDB and persist across reloads.
+The app requests persistent storage with `navigator.storage.persist()` so the browser is less likely to evict the data.
 
 Location is only retrieved when you press the button and is not tracked continuously.

--- a/app.js
+++ b/app.js
@@ -5,6 +5,16 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+// Request persistent storage so the notes database is less likely to be
+// cleared by the browser under storage pressure.
+if (navigator.storage && navigator.storage.persist) {
+  window.addEventListener('load', () => {
+    navigator.storage.persist().then(granted => {
+      console.log(`Persistent storage ${granted ? 'granted' : 'denied'}`);
+    });
+  });
+}
+
 // IndexedDB wrapper
 const dbPromise = new Promise((resolve, reject) => {
   const request = indexedDB.open('notes-db', 1);


### PR DESCRIPTION
## Summary
- Request persistent storage on load so stored notes are less likely to be cleared by the browser
- Document persistent storage behavior in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ff2c3d100832abcb6d0bd1096eb8f