### PR TITLE
Add browser place search for remote notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
   </header>
 
   <main class="content">
+    <form id="searchForm">
+      <input id="searchQuery" placeholder="Search for a place" />
+      <button type="submit">Search</button>
+    </form>
+    <div id="searchResult"></div>
     <ul id="notesList"></ul>
 
     <form id="noteForm">


### PR DESCRIPTION
## Summary
- allow searching for a place by name via Nominatim and rate limit lookups
- enable adding notes for searched locations instead of only current position

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689632e07d20832a9198be38c7429a23