### PR TITLE
Add cancel option for note creation

### DIFF
--- a/app.js
+++ b/app.js
@@ -101,6 +101,7 @@ const locBtn = document.getElementById('locBtn');
 const notesList = document.getElementById('notesList');
 const addNoteBtn = document.getElementById('addNoteBtn');
 const noteForm = document.getElementById('noteForm');
+const cancelNoteBtn = document.getElementById('cancelNoteBtn');
 const searchForm = document.getElementById('searchForm');
 const searchQuery = document.getElementById('searchQuery');
 const searchResult = document.getElementById('searchResult');
@@ -113,6 +114,12 @@ addNoteBtn.addEventListener('click', () => {
     // Closing the form clears any previous search details.
     searchResult.textContent = '';
   }
+});
+
+cancelNoteBtn.addEventListener('click', () => {
+  noteForm.reset();
+  noteForm.style.display = 'none';
+  searchResult.textContent = '';
 });
 
 /**

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
       <input id="title" placeholder="Title" required />
       <textarea id="body" placeholder="Note body"></textarea>
       <button type="submit">Add note</button>
+      <button type="button" id="cancelNoteBtn">Cancel</button>
     </form>
 
     <button id="addNoteBtn" class="fab">+</button>

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -92,6 +92,18 @@ test('closing note form clears search result', async () => {
   assert.equal(win.searchResult.textContent, '');
 });
 
+test('cancel button hides form and clears search result', async () => {
+  const fetchStub = () => Promise.resolve({ json: () => [{ lat: '11', lon: '12', display_name: 'CancelTest' }] });
+  const win = setup({ fetch: fetchStub });
+  win.document.getElementById('searchQuery').value = 'cancel';
+  win.document.getElementById('searchForm').dispatchEvent(new win.Event('submit', { bubbles: true, cancelable: true }));
+  await new Promise(r => setTimeout(r, 0));
+  assert.equal(win.document.getElementById('noteForm').style.display, 'block');
+  win.document.getElementById('cancelNoteBtn').dispatchEvent(new win.Event('click', { bubbles: true }));
+  assert.equal(win.document.getElementById('noteForm').style.display, 'none');
+  assert.equal(win.searchResult.textContent, '');
+});
+
 test('search result cleared after failed note save', async () => {
   const fetchStub = () => Promise.resolve({ json: () => [{ lat: '9', lon: '10', display_name: 'Qux' }] });
   let alertMsg = '';


### PR DESCRIPTION
## Summary
- add Cancel button to note form so users can dismiss note creation
- hide and reset form on cancel
- test cancel behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689911d6fddc832aaef59718356f9f3b