### PR TITLE
Fetch location when adding note without prior geolocation

### DIFF
--- a/test/app.test.js
+++ b/test/app.test.js
@@ -188,3 +188,19 @@ test('multiple searches update coordinates', async () => {
   assert.equal(win.searchResult.textContent, 'Second');
 });
 
+test('clicking add note triggers geolocation when none fetched', async () => {
+  const win = setup();
+  let called = false;
+  const fakePos = { coords: { latitude: 13, longitude: 14 }, timestamp: 0 };
+  win.navigator.geolocation = {
+    getCurrentPosition(success) {
+      called = true;
+      success(fakePos);
+    }
+  };
+  win.document.getElementById('addNoteBtn').dispatchEvent(new win.Event('click', { bubbles: true }));
+  await new Promise(r => setTimeout(r, 0));
+  assert.ok(called);
+  assert.deepEqual(win.locationStore.getCurrent().coords, { latitude: 13, longitude: 14 });
+});
+


### PR DESCRIPTION
## Summary
- Automatically request device location when opening the note form if no location was previously fetched
- Centralize geolocation logic in a shared `fetchLocation` function reused by the Get location button
- Add regression test for auto-fetching location on note creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899133a0d34832abdd962ea0695ac4d