### PR TITLE
Fix service worker paths for subdirectory deployment

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 // Service worker registration
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+    navigator.serviceWorker.register('sw.js');
   });
 }
 

--- a/sw.js
+++ b/sw.js
@@ -1,12 +1,12 @@
 const CACHE_NAME = 'place-notes-v1';
 const ASSETS = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/app.js',
-  '/manifest.webmanifest',
-  '/icons/icon-192.png',
-  '/icons/icon-512.png'
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './manifest.webmanifest',
+  './icons/icon-192.png',
+  './icons/icon-512.png'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- Register service worker using a relative path so it loads from the subdirectory
- Cache assets using relative URLs so offline assets are served correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899170eb588832ab82e9ec52d63d36e