### PR TITLE
Add note search by text or location

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
       <button type="submit">Search</button>
     </form>
     <div id="searchResult"></div>
+    <form id="noteSearchForm">
+      <input id="noteSearchQuery" placeholder="Search notes by text or place" />
+      <button type="submit">Find notes</button>
+    </form>
     <ul id="notesList"></ul>
 
     <form id="noteForm">

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -233,3 +233,25 @@ test('service worker update prompts for reload', async () => {
   assert.equal(alertMsg, 'New version available. Please reload.');
 });
 
+test('searchNotes filters by text', async () => {
+  const win = setup();
+  win.getAllNotes = async () => [
+    { id: 1, title: 'Hello', body: 'World', lat: 0, lon: 0 },
+    { id: 2, title: 'Bye', body: 'Moon', lat: 1, lon: 1 }
+  ];
+  const res = await win.searchNotes({ text: 'hell' });
+  assert.equal(res.length, 1);
+  assert.equal(res[0].id, 1);
+});
+
+test('searchNotes filters by location', async () => {
+  const win = setup();
+  win.getAllNotes = async () => [
+    { id: 1, title: 'A', body: '', lat: 0, lon: 0 },
+    { id: 2, title: 'B', body: '', lat: 0.002, lon: 0 }
+  ];
+  const res = await win.searchNotes({ lat: 0, lon: 0, radius: 150 });
+  assert.equal(res.length, 1);
+  assert.equal(res[0].id, 1);
+});
+


### PR DESCRIPTION
## Summary
- allow searching stored notes by text or geographic radius
- expose search through new form and render helper for results
- add unit tests for text and location searches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f60ea6590832ab4ac9cd91dcd13aa